### PR TITLE
Fix panic when max_retries/timeout/priority/delay is set without idempotency_key

### DIFF
--- a/src/runner/runner.rs
+++ b/src/runner/runner.rs
@@ -1255,17 +1255,18 @@ impl<'a> ActivityBuilder<'a> {
             || self.delay.is_some()
             || self.idempotency_key.is_some()
         {
-            let idempotency_key = self.idempotency_key.unwrap();
-            let idempotency_key = (
-                format!("{}-{}", idempotency_key.0, self.activity_type),
-                idempotency_key.1,
-            );
+            let idempotency_key = self.idempotency_key.map(|(key, behavior)| {
+                (
+                    format!("{}-{}", key, self.activity_type),
+                    behavior,
+                )
+            });
             Some(ActivityOption {
                 priority: self.priority,
                 max_retries: self.max_retries.unwrap_or(3),
                 timeout_seconds: self.timeout.map(|d| d.as_secs()).unwrap_or(300),
                 delay_seconds: self.delay.map(|d| d.as_secs()),
-                idempotency_key: Some(idempotency_key),
+                idempotency_key,
             })
         } else {
             None


### PR DESCRIPTION
## Description

Fixes a panic that occurs when `max_retries`, `timeout`, `priority`, or `delay` is set, but `idempotency_key` is not provided.

## Problem

The code at line 1258 was calling `unwrap()` on `self.idempotency_key` without checking if it was `Some`. This caused a panic when:
- Any of `priority`, `max_retries`, `timeout`, or `delay` was set
- But `idempotency_key` was `None`

## Solution

Changed the code to use `Option::map()` instead of `unwrap()`, which properly handles the case where `idempotency_key` is `None`. The `idempotency_key` field in `ActivityOption` is already optional, so this change aligns the code with that design.

## Changes

- Replaced `unwrap()` with `Option::map()` to safely handle `None` values
- The idempotency key is now only formatted and set if it's provided
- Other options can now be set independently without requiring an idempotency key

## Testing

- Code compiles successfully
- No linter errors
- Fixes the panic scenario described in #40

## Related Issues

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Optimized internal idempotency key handling logic for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->