### PR TITLE
Cap exponential backoff retry delay at 1 hour

### DIFF
--- a/src/queue/queue.rs
+++ b/src/queue/queue.rs
@@ -1193,7 +1193,9 @@ impl ActivityQueueTrait for ActivityQueue {
             retry_activity.status = ActivityStatus::Retrying;
 
             // Add exponential backoff delay, capped at 1 hour
-            let delay_seconds = (retry_activity.retry_delay_seconds * 2_u64.pow(retry_activity.retry_count))
+            let backoff_multiplier = 2_u64.pow(retry_activity.retry_count);
+            let delay_seconds = retry_activity.retry_delay_seconds
+                .saturating_mul(backoff_multiplier)
                 .min(Self::MAX_RETRY_DELAY_SECONDS);
             let scheduled_at = chrono::Utc::now() + chrono::Duration::seconds(delay_seconds as i64);
             retry_activity.scheduled_at = Some(scheduled_at);


### PR DESCRIPTION
This PR implements the cap on exponential backoff retry delays as requested in #43.

## Changes
- Added `MAX_RETRY_DELAY_SECONDS` constant (3600 seconds / 1 hour)
- Modified retry delay calculation to cap at 1 hour: `(retry_delay_seconds * 2^retry_count).min(MAX_RETRY_DELAY_SECONDS)`
- Updated documentation to reflect the 1-hour cap

## Impact
Prevents excessive wait times for retries by ensuring the exponential backoff delay never exceeds 1 hour, regardless of retry count.

Fixes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Task retry now uses exponential backoff with a maximum 1-hour delay cap for more predictable retries.
  * Queue lease handling adds a 10-second safety buffer when extending leases to reduce race conditions.
  * Added debug logging around lease extension to improve observability and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->