### PR TITLE
Fix overflow in retry backoff calculation

### DIFF
--- a/src/queue/queue.rs
+++ b/src/queue/queue.rs
@@ -1196,7 +1196,7 @@ impl ActivityQueueTrait for ActivityQueue {
             retry_activity.status = ActivityStatus::Retrying;
 
             // Add exponential backoff delay, capped at 1 hour
-            let backoff_multiplier = 2_u64.pow(retry_activity.retry_count);
+            let backoff_multiplier = 2_u64.saturating_pow(retry_activity.retry_count);
             let delay_seconds = retry_activity.retry_delay_seconds
                 .saturating_mul(backoff_multiplier)
                 .min(Self::MAX_RETRY_DELAY_SECONDS);


### PR DESCRIPTION
Fixes overflow in exponential backoff calculation by capping exponent to 63.

`2_u64.pow(retry_count)` overflows when `retry_count >= 64`, causing undefined behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an overflow in the exponential backoff calculation for very high retry counts, preventing incorrect delay values. This preserves existing retry timing for typical cases and improves stability and predictability in extreme retry scenarios, reducing the risk of excessive or clamped delays affecting retry behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->